### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='llconfig',
-    version='1.0.0',
+    version='1.0.1',
     packages=['llconfig'],
     license='MIT',
     author='Heureka.cz',


### PR DESCRIPTION
Béďa sice opravil deprecation warning v posledním commitu, ale už neudělal release. Takže bump verze na 1.0.1.