### PR TITLE
Fix converters.json for python 3.9 and above.

### DIFF
--- a/llconfig/converters.py
+++ b/llconfig/converters.py
@@ -21,4 +21,4 @@ def json(val):
     """
     A convenient converter that JSON-deserializes strings.
     """
-    return _json.loads(val, encoding='utf-8')
+    return _json.loads(val)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='llconfig',
-    version='2.0.0',
+    version='2.0.1',
     packages=['llconfig'],
     license='Apache 2.0',
     author='Heureka.cz',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37
+envlist = py35,py36,py37,py38,py39
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Fix behaviour of `converters.json` in python 3.9 and above. The `encoding` parameter was deprecated since python 3.1.

Also add py38 and py39 to tox to test it.